### PR TITLE
fix: replace boilerplate placeholders with correct IONOS Cloud values

### DIFF
--- a/README-PROVIDER.md
+++ b/README-PROVIDER.md
@@ -1,6 +1,6 @@
-# Foo Resource Provider
+# IONOS Cloud Resource Provider
 
-The Foo Resource Provider lets you manage [Foo](http://example.com) resources.
+The IONOS Cloud Resource Provider lets you manage [IONOS Cloud](https://cloud.ionos.com/) resources.
 
 ## Installing
 
@@ -11,13 +11,13 @@ This package is available for several languages/platforms:
 To use from JavaScript or TypeScript in Node.js, install using either `npm`:
 
 ```bash
-npm install @pulumi/foo
+npm install @ionos-cloud/sdk-pulumi
 ```
 
 or `yarn`:
 
 ```bash
-yarn add @pulumi/foo
+yarn add @ionos-cloud/sdk-pulumi
 ```
 
 ### Python
@@ -25,7 +25,7 @@ yarn add @pulumi/foo
 To use from Python, install using `pip`:
 
 ```bash
-pip install pulumi_foo
+pip install pulumi_ionoscloud
 ```
 
 ### Go
@@ -33,7 +33,7 @@ pip install pulumi_foo
 To use from Go, use `go get` to grab the latest version of the library:
 
 ```bash
-go get github.com/pulumi/pulumi-foo/sdk/go/...
+go get github.com/ionos-cloud/pulumi-ionoscloud/sdk
 ```
 
 ### .NET
@@ -41,16 +41,17 @@ go get github.com/pulumi/pulumi-foo/sdk/go/...
 To use from .NET, install using `dotnet add package`:
 
 ```bash
-dotnet add package Pulumi.Foo
+dotnet add package Ionoscloud.Pulumi.Ionoscloud
 ```
 
 ## Configuration
 
-The following configuration points are available for the `foo` provider:
+The following configuration points are available for the `ionoscloud` provider:
 
-- `foo:apiKey` (environment: `FOO_API_KEY`) - the API key for `foo`
-- `foo:region` (environment: `FOO_REGION`) - the region in which to deploy resources
+- `ionoscloud:username` (environment: `IONOS_USERNAME`) - the username for IONOS Cloud API authentication
+- `ionoscloud:password` (environment: `IONOS_PASSWORD`) - the password for IONOS Cloud API authentication
+- `ionoscloud:token` (environment: `IONOS_TOKEN`) - the API token for authentication (alternative to username/password)
 
 ## Reference
 
-For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/foo/api-docs/).
+For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/ionoscloud/api-docs/).

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -16,7 +16,7 @@ func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
-			"@pulumi/ionoscloud",
+			"@ionos-cloud/sdk-pulumi",
 		},
 	})
 
@@ -64,7 +64,7 @@ func getCSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
-			"Pulumi.ionoscloud",
+			"Ionoscloud.Pulumi.Ionoscloud",
 		},
 	})
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -139,7 +139,8 @@ func Provider() tfbridge.ProviderInfo {
 		//
 		// You may host a logo on a domain you control or add an PNG logo (100x100) for your package
 		// in your repository and use the raw content URL for that file as your logo URL.
-		LogoURL: "https://raw.githubusercontent.com/ionos-cloud/pulumi-ionoscloud/refs/heads/main/.github/LOGO_IONOS_Blue_RGB.png",
+		LogoURL: "https://raw.githubusercontent.com/ionos-cloud/" +
+			"pulumi-ionoscloud/refs/heads/main/.github/LOGO_IONOS_Blue_RGB.png",
 		// PluginDownloadURL is an optional URL used to download the Provider
 		// for use in Pulumi programs
 		// e.g. https://github.com/org/pulumi-provider-name/releases/download/v${VERSION}/


### PR DESCRIPTION
## Summary
- **README-PROVIDER.md**: Replace all "Foo" template placeholders with actual IONOS Cloud provider names, correct package names (`@ionos-cloud/sdk-pulumi`, `pulumi_ionoscloud`, `Ionoscloud.Pulumi.Ionoscloud`), real configuration variables (`ionoscloud:username`, `ionoscloud:password`, `ionoscloud:token`), and valid links
- **examples/examples_test.go**: Fix Node.js test dependency from `@pulumi/ionoscloud` to `@ionos-cloud/sdk-pulumi` (matching `sdk/nodejs/package.json`) and .NET test dependency from `Pulumi.ionoscloud` to `Ionoscloud.Pulumi.Ionoscloud` (matching `sdk/dotnet/Ionoscloud.Pulumi.Ionoscloud.csproj`)

## Test plan
- [ ] Verify package names match actual SDK artifacts in `sdk/nodejs/package.json` and `sdk/dotnet/*.csproj`
- [ ] Verify configuration variables match those documented in `docs/installation-configuration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)