### PR TITLE
fix: consolidate pending doc, README, and naming fixes

### DIFF
--- a/README-PROVIDER.md
+++ b/README-PROVIDER.md
@@ -1,6 +1,6 @@
-# Foo Resource Provider
+# IONOS Cloud Resource Provider
 
-The Foo Resource Provider lets you manage [Foo](http://example.com) resources.
+The IONOS Cloud Resource Provider lets you manage [IONOS Cloud](https://cloud.ionos.com/) resources.
 
 ## Installing
 
@@ -11,13 +11,13 @@ This package is available for several languages/platforms:
 To use from JavaScript or TypeScript in Node.js, install using either `npm`:
 
 ```bash
-npm install @pulumi/foo
+npm install @ionos-cloud/sdk-pulumi
 ```
 
 or `yarn`:
 
 ```bash
-yarn add @pulumi/foo
+yarn add @ionos-cloud/sdk-pulumi
 ```
 
 ### Python
@@ -25,7 +25,7 @@ yarn add @pulumi/foo
 To use from Python, install using `pip`:
 
 ```bash
-pip install pulumi_foo
+pip install pulumi_ionoscloud
 ```
 
 ### Go
@@ -33,7 +33,7 @@ pip install pulumi_foo
 To use from Go, use `go get` to grab the latest version of the library:
 
 ```bash
-go get github.com/pulumi/pulumi-foo/sdk/go/...
+go get github.com/ionos-cloud/pulumi-ionoscloud/sdk
 ```
 
 ### .NET
@@ -41,16 +41,17 @@ go get github.com/pulumi/pulumi-foo/sdk/go/...
 To use from .NET, install using `dotnet add package`:
 
 ```bash
-dotnet add package Pulumi.Foo
+dotnet add package Ionoscloud.Pulumi.Ionoscloud
 ```
 
 ## Configuration
 
-The following configuration points are available for the `foo` provider:
+The following configuration points are available for the `ionoscloud` provider:
 
-- `foo:apiKey` (environment: `FOO_API_KEY`) - the API key for `foo`
-- `foo:region` (environment: `FOO_REGION`) - the region in which to deploy resources
+- `ionoscloud:username` (environment: `IONOS_USERNAME`) - the username for IONOS Cloud API authentication
+- `ionoscloud:password` (environment: `IONOS_PASSWORD`) - the password for IONOS Cloud API authentication
+- `ionoscloud:token` (environment: `IONOS_TOKEN`) - the API token for authentication (alternative to username/password)
 
 ## Reference
 
-For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/foo/api-docs/).
+For detailed reference documentation, please visit [the Pulumi registry](https://www.pulumi.com/registry/packages/ionoscloud/api-docs/).

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -8,7 +8,7 @@ The `Ionoscloud` provider for Pulumi can be used to provision most of the resour
 
 The provider needs to be configured with proper credentials before it can be used.
 
-We strongly suggest to use token authentication for security purposes. You can find more information [here](https://docs.ionos.com/cloud/set-up-ionos-cloud/management/token-management).
+We strongly suggest to use token authentication for security purposes. You can find more information [here](https://docs.ionos.com/cloud/set-up-ionos-cloud/management/identity-access-management/token-manager).
 
 ## Example
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -16,7 +16,7 @@ func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
-			"@pulumi/ionoscloud",
+			"@ionos-cloud/sdk-pulumi",
 		},
 	})
 
@@ -64,7 +64,7 @@ func getCSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
-			"Pulumi.ionoscloud",
+			"Ionoscloud.Pulumi.Ionoscloud",
 		},
 	})
 


### PR DESCRIPTION
Apply the still-applicable changes from PRs #65, #73, #74 onto a fresh branch off main, dropping the parts already merged or superseded:

- docs/_index.md: fix the broken token-management doc link ->
  identity-access-management/token-manager (#65). The installation-
  configuration.md half of #65 is omitted -- main already has it fixed.
- README-PROVIDER.md: replace the "Foo" boilerplate placeholders with real IONOS Cloud values -- package names (@ionos-cloud/sdk-pulumi, pulumi_ionoscloud, Ionoscloud.Pulumi.Ionoscloud, sdk go module), config keys (ionoscloud:username/password/token) and registry link (#73).
- examples/examples_test.go: correct the Node.js dependency (@pulumi/ionoscloud -> @ionos-cloud/sdk-pulumi) and .NET dependency (Pulumi.ionoscloud -> Ionoscloud.Pulumi.Ionoscloud) (#73).
- provider/resources.go: fix the inconsistent InMemoryDB snapshot data source token getInmemorydbSnapshot -> getInMemoryDBSnapshot to match the getInMemoryDB* convention used by every neighboring token (#74).

The #73 LogoURL line-break hunk is omitted: main already suppresses the lll linter on that line via //nolint:lll.